### PR TITLE
Add README with usage notes

### DIFF
--- a/.macos
+++ b/.macos
@@ -5,15 +5,6 @@
 # It is based on the script from Jeff Geerling:
 # https://github.com/geerlingguy/dotfiles/blob/master/.osx
 #
-# To run the script, first make it executable:
-#   chmod +x .osx
-#
-# Then run it:
-#   sudo ./osx
-#
-# Options:
-#   --no-restart: Don't restart any apps or services after running the script.
-#
 # If you want to figure out what default needs changing, do the following:
 #
 #   1. `cd /tmp`
@@ -31,7 +22,7 @@ if [[ $EUID -ne 0 ]]; then
   printf "Certain commands will not be run without sudo privileges. To run as root, run the same command prepended with 'sudo', for example: $ sudo $0\n\n" | fold -s -w 80
 else
   RUN_AS_ROOT=true
-  # Update existing `sudo` timestamp until `.osx` has finished
+  # Update existing `sudo` timestamp until this script has finished
   while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 fi
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Dotfiles
+
+These dotfiles configure a minimal zsh environment. A companion `.macos` script can configure system defaults on macOS.
+Finder hides files that start with a period, so the repository may look empty when opened normally. Use `ls -a` or press `Cmd+Shift+.` in Finder to reveal them.
+
+## Contents
+
+- `.zshrc` – a small zsh configuration providing a coloured prompt.
+- `.macos` – a script that configures many macOS preferences.
+
+## Running the macOS setup script
+
+`.macos` is not sourced like a typical dotfile. To run it:
+
+```bash
+# Make the script executable (only once)
+chmod +x .macos
+
+# Run it with sudo so all settings can be applied
+sudo ./.macos
+```
+
+Pass `--no-restart` if you do not want affected applications to restart
+automatically.
+
+


### PR DESCRIPTION
## Summary
- rename `macos` helper script to `.macos`
- document hidden filename in the README

## Testing
- `bash -n .macos`
- `bash -n .zshrc`


------
https://chatgpt.com/codex/tasks/task_e_684749ae117083229e78d94877dace41